### PR TITLE
Fix Grabbing text in the PPNode Sampler view

### DIFF
--- a/src/GToolkit4PetitParser2/PP2Node.extension.st
+++ b/src/GToolkit4PetitParser2/PP2Node.extension.st
@@ -139,7 +139,7 @@ PP2Node >> gtSamplerFor: aView [
 				icon: BrGlamorousVectorIcons playinspect;
 				action: [ :aButton |
 					| input context | 
-					input := (tab viewContentElement childAt: 1) text asString.
+					input := (tab viewContentElement childWithId: #editor) text asString.
 					context := PP2RecordingContext new.
 					(self 
 						deoptimize;


### PR DESCRIPTION
Grabbing text for the PPNode broke, I assume it's because the UI shifted, so the `childAt: 1` is now a BrVerticalPane rather than the editor.

To make this safer I just ask for a child with the id `#editor`, which gives us the editor widget to ask text from.


Here is an example of the error in action before the changes
![](https://pomf2.lain.la/f/mr09219d.png)